### PR TITLE
custom serializer

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -47,6 +47,7 @@ my $builder = $class->new(
 		'Test::FailWarnings'   => 0,
 		'Test::More'           => 0.94,
 		'Test::Type'           => 0,
+		'JSON::XS'             => 0,
 	},
 	requires             =>
 	{

--- a/t/31-enqueue-json.t
+++ b/t/31-enqueue-json.t
@@ -1,0 +1,88 @@
+#!perl -T
+
+use strict;
+use warnings;
+
+use Test::Exception;
+use Test::FailWarnings;
+use Test::More tests => 7;
+
+use lib 't/';
+use LocalTest;
+
+use Queue::DBI;
+use JSON::XS;
+
+
+my $dbh = LocalTest::ok_database_handle();
+my $JSON = JSON::XS->new;
+
+# Instantiate the queue object.
+my $queue;
+lives_ok(
+	sub
+	{
+		$queue = Queue::DBI->new(
+			'queue_name'      => 'test1',
+			'database_handle' => $dbh,
+			'cleanup_timeout' => 3600,
+			'verbose'         => 0,
+			'serialize_freeze'  => sub { $JSON->encode($_[0]) },
+			'serialize_thaw'    => sub { $JSON->decode($_[0]) },
+		);
+	},
+	'Instantiate a new Queue::DBI object.',
+);
+
+# Insert data.
+my $data =
+{
+	block1 => 141592653,
+	block2 => 589793238,
+	block3 => 462643383,
+};
+lives_ok(
+	sub
+	{
+		$queue->enqueue( $data );
+	},
+	'Queue data.',
+);
+
+# Retrieve data.
+my $queue_element;
+lives_ok(
+	sub
+	{
+		$queue_element = $queue->next();
+	},
+	'Call to retrieve the next item in the queue.',
+);
+isa_ok(
+	$queue_element,
+	'Queue::DBI::Element',
+	'Object returned by next()',
+);
+
+# Lock.
+lives_ok(
+	sub
+	{
+		$queue_element->lock()
+		||
+		die 'Cannot lock element';
+	},
+	'Lock element.',
+);
+
+# Remove.
+lives_ok(
+	sub
+	{
+		$queue_element->success()
+		||
+		die 'Cannot mark as successfully processed';
+	},
+	'Mark as successfully processed.',
+);
+


### PR DESCRIPTION
This is my draft for the custom serializer.

I tried to mimic your coding style. I did not define a default sub implementing the default freeze/thaw algorithm but having a ternary ?: like the table name  accessor in new freeze and thaw method.

Defining a custom serializer is "initialization only", both freeze and thaw must be defined. There is no check which checks for a valid code ref yet.

31-enqueue-json.t is copy of 30-enqueue.t with a few changes and a new dependency to JSON::XS. 
Maybe we should have a custom test algorithm which is implemented without adding additional dependencies, for example a reverse Base64 encoding.
